### PR TITLE
Fix incorrect module naming & release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+The changelog is currently hosted on [the GitHub Releases page](https://github.com/agilgur5/django-api-decorators/releases).<br>
+It is currently mostly a summary and list of commits made before any tag.
+The commits in this library mostly follow a convention and tend to be quite detailed.
+
+This project adheres to [Semantic Versioning](http://semver.org/).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+include CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # django-api-decorators
 
+[//]: # (releases / versioning)
 [![PyPI version](https://img.shields.io/pypi/v/django-api-decorators.svg)](https://pypi.org/project/django-api-decorators/)
 [![releases](https://img.shields.io/github/tag-pre/agilgur5/django-api-decorators.svg)](https://github.com/agilgur5/django-api-decorators/releases)
 [![commits](https://img.shields.io/github/commits-since/agilgur5/django-api-decorators/latest.svg)](https://github.com/agilgur5/django-api-decorators/commits/master)
 
+[//]: # (downloads)
 [![dm](https://img.shields.io/pypi/dm/django-api-decorators.svg)](https://pypi.org/project/django-api-decorators/)
 [![dw](https://img.shields.io/pypi/dw/django-api-decorators.svg)](https://pypi.org/project/django-api-decorators/)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please submit a PR or file an issue if you have a compatibility problem or have 
 `@method_exclusive`, per docstring: `Checks if request.method is equal to method, if not, returns a 405 not allowed response`. Example:
 
 ```python
-from django-api-decorators import method_exlusive
+from django_api_decorators import method_exlusive
 
 @method_exclusive('GET')
 def get_latest_public_posts(request):
@@ -58,7 +58,7 @@ def get_latest_public_posts(request):
 `@require_auth`, per docstring: `Checks if the request was made by an authenticated user, and if not, returns a 401 unauthorized response`. Example:
 
 ```python
-from django-api-decorators import method_exclusive, require_auth
+from django_api_decorators import method_exclusive, require_auth
 
 @method_exclusive('GET')
 @require_auth
@@ -75,7 +75,7 @@ by building on top of the `@require_auth` decorator. For instance:
 from functools import wraps
 
 from django.http import HttpResponse
-from django-api-decorators import require_auth
+from django_api_decorators import require_auth
 
 def tenant_exclusive(func):
     """
@@ -97,7 +97,7 @@ def tenant_exclusive(func):
 
 ```python
 from django.shortcuts import get_object_or_404
-from django-api-decorators import method_exclusive, clean_form, require_auth
+from django_api_decorators import method_exclusive, clean_form, require_auth
 
 from posts.models import Post
 from posts.forms import AddFavForm
@@ -117,7 +117,7 @@ def add_fav(request, cd):
 `@clean_forms`, per docstring: `Cleans the data in the POST or GET params using the form_class specified. Responds with a 400 bad request if any of the forms are invalid with the errors specified in the form as JSON. Adds the cleaned data as a kwarg (cd_list) to the decorated function`. Example:
 
 ```python
-from django-api-decorators import method_exclusive, clean_forms, require_auth
+from django_api_decorators import method_exclusive, clean_forms, require_auth
 
 from posts.models import Post
 from posts.forms import CreatePostForm

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # django-api-decorators
 
-[//]: # (releases / versioning)
+<!-- releases / versioning -->
 [![PyPI version](https://img.shields.io/pypi/v/django-api-decorators.svg)](https://pypi.org/project/django-api-decorators/)
 [![releases](https://img.shields.io/github/tag-pre/agilgur5/django-api-decorators.svg)](https://github.com/agilgur5/django-api-decorators/releases)
 [![commits](https://img.shields.io/github/commits-since/agilgur5/django-api-decorators/latest.svg)](https://github.com/agilgur5/django-api-decorators/commits/master)
-
-[//]: # (downloads)
+<br><!-- downloads -->
 [![dm](https://img.shields.io/pypi/dm/django-api-decorators.svg)](https://pypi.org/project/django-api-decorators/)
 [![dw](https://img.shields.io/pypi/dw/django-api-decorators.svg)](https://pypi.org/project/django-api-decorators/)
 

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,2 @@
+# changelog-maker only gets name from package.json, so do a replace
+npx @agilgur5/changelog-maker | sed 's_nodejs/node_agilgur5/django-api-decorators_';

--- a/decorators.py
+++ b/decorators.py
@@ -1,98 +1,10 @@
-import json
-from functools import wraps
+"""
+This is just a pure wrapper / alias module around django_api_decorators to
+still be able to import it with the original, unintended name of decorators.
+See https://github.com/agilgur5/django-serializable-model/issues/2, which had
+the same issue and its changes were cherry-picked here.
+In the first major/breaking release, v1.0.0, this file should be deleted and
+the module removed from `setup.py`.
+"""
 
-import django
-from django.http import HttpResponse, HttpResponseNotAllowed
-
-
-def method_exclusive(method):
-    """
-    Checks if request.method is equal to method, if not, returns a
-    405 not allowed response
-    """
-    def decorator(func):
-        @wraps(func)
-        def func_wrapper(request, *args, **kwargs):
-            if request.method != method:
-                return HttpResponseNotAllowed([method])
-            return func(request, *args, **kwargs)
-        return func_wrapper
-    return decorator
-
-
-def require_auth(func):
-    """
-    Checks if the request was made by an authenticated user, and if not,
-    returns a 401 unauthorized response
-    """
-    @wraps(func)
-    def func_wrapper(request, *args, **kwargs):
-        # backward compatibility for Django < 1.10
-        if django.VERSION < (1, 10):
-            is_authenticated = request.user.is_authenticated()
-        else:
-            is_authenticated = request.user.is_authenticated
-
-        if not is_authenticated:
-            return HttpResponse(status=401)
-        return func(request, *args, **kwargs)
-    return func_wrapper
-
-
-def clean_form(form_class):
-    """
-    Cleans the data in the POST or GET params using the form_class specified.
-    Responds with a 400 bad request if the form is invalid with the errors
-    specified in the form as JSON.
-    Adds the cleaned data as a kwarg (cd) to the decorated function.
-    """
-    def decorator(func):
-        @wraps(func)
-        def func_wrapper(request, *args, **kwargs):
-            form = form_class(
-                (request.POST if request.method == 'POST' else request.GET),
-                request.FILES
-            )
-            if not form.is_valid():
-                return HttpResponse(json.dumps(form.errors), status=400)
-            kwargs['cd'] = form.cleaned_data
-            return func(request, *args, **kwargs)
-        return func_wrapper
-    return decorator
-
-
-def clean_forms(form_class, attribute, required=True):
-    """
-    Cleans the data in the POST or GET params using the form_class specified.
-    Responds with a 400 bad request if any of the forms are invalid with the
-    errors specified in the form as JSON.
-    Adds the cleaned data as a kwarg (cd_list) to the decorated function.
-    """
-    def decorator(func):
-        @wraps(func)
-        def func_wrapper(request, *args, **kwargs):
-            request_dict = (request.POST
-                            if request.method == 'POST' else request.GET)
-            data_list = request_dict.getlist(attribute + '[]')
-            kwargs['cd_list'] = []
-
-            if not data_list:
-                # error out if not existent
-                if required:
-                    obj = {}
-                    obj[attribute] = 'This field is required'
-                    return HttpResponse(json.dumps(obj), status=400)
-                # early return if not required
-                return func(request, *args, **kwargs)
-
-            # iterate through and validate each form submitted
-            for data in data_list:
-                # must JSON.loads as Django QueryDicts can't handle nesting
-                form = form_class(json.loads(data))
-                if not form.is_valid():
-                    return HttpResponse(json.dumps(form.errors), status=400)
-                kwargs['cd_list'].append(form.cleaned_data)
-
-            return func(request, *args, **kwargs)
-        return func_wrapper
-    return decorator
+from django_api_decorators import *  # noqa F403, F401

--- a/django_api_decorators.py
+++ b/django_api_decorators.py
@@ -1,0 +1,98 @@
+import json
+from functools import wraps
+
+import django
+from django.http import HttpResponse, HttpResponseNotAllowed
+
+
+def method_exclusive(method):
+    """
+    Checks if request.method is equal to method, if not, returns a
+    405 not allowed response
+    """
+    def decorator(func):
+        @wraps(func)
+        def func_wrapper(request, *args, **kwargs):
+            if request.method != method:
+                return HttpResponseNotAllowed([method])
+            return func(request, *args, **kwargs)
+        return func_wrapper
+    return decorator
+
+
+def require_auth(func):
+    """
+    Checks if the request was made by an authenticated user, and if not,
+    returns a 401 unauthorized response
+    """
+    @wraps(func)
+    def func_wrapper(request, *args, **kwargs):
+        # backward compatibility for Django < 1.10
+        if django.VERSION < (1, 10):
+            is_authenticated = request.user.is_authenticated()
+        else:
+            is_authenticated = request.user.is_authenticated
+
+        if not is_authenticated:
+            return HttpResponse(status=401)
+        return func(request, *args, **kwargs)
+    return func_wrapper
+
+
+def clean_form(form_class):
+    """
+    Cleans the data in the POST or GET params using the form_class specified.
+    Responds with a 400 bad request if the form is invalid with the errors
+    specified in the form as JSON.
+    Adds the cleaned data as a kwarg (cd) to the decorated function.
+    """
+    def decorator(func):
+        @wraps(func)
+        def func_wrapper(request, *args, **kwargs):
+            form = form_class(
+                (request.POST if request.method == 'POST' else request.GET),
+                request.FILES
+            )
+            if not form.is_valid():
+                return HttpResponse(json.dumps(form.errors), status=400)
+            kwargs['cd'] = form.cleaned_data
+            return func(request, *args, **kwargs)
+        return func_wrapper
+    return decorator
+
+
+def clean_forms(form_class, attribute, required=True):
+    """
+    Cleans the data in the POST or GET params using the form_class specified.
+    Responds with a 400 bad request if any of the forms are invalid with the
+    errors specified in the form as JSON.
+    Adds the cleaned data as a kwarg (cd_list) to the decorated function.
+    """
+    def decorator(func):
+        @wraps(func)
+        def func_wrapper(request, *args, **kwargs):
+            request_dict = (request.POST
+                            if request.method == 'POST' else request.GET)
+            data_list = request_dict.getlist(attribute + '[]')
+            kwargs['cd_list'] = []
+
+            if not data_list:
+                # error out if not existent
+                if required:
+                    obj = {}
+                    obj[attribute] = 'This field is required'
+                    return HttpResponse(json.dumps(obj), status=400)
+                # early return if not required
+                return func(request, *args, **kwargs)
+
+            # iterate through and validate each form submitted
+            for data in data_list:
+                # must JSON.loads as Django QueryDicts can't handle nesting
+                form = form_class(json.loads(data))
+                if not form.is_valid():
+                    return HttpResponse(json.dumps(form.errors), status=400)
+                kwargs['cd_list'].append(form.cleaned_data)
+
+            return func(request, *args, **kwargs)
+        return func_wrapper
+    return decorator

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
     ],
     keywords=('django api rest ad-hoc decorator json dict form formset ' +
               'validation'),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,12 @@ setup(
     ],
     keywords=('django api rest ad-hoc decorator json dict form formset ' +
               'validation'),
-    py_modules=['decorators'],
+    py_modules=[
+        'django_api_decorators',
+        # this is the original, unintended name, and should be removed in the
+        # first breaking/major release, v1.0.0. See `decorators.py` comment.
+        'decorators'
+    ],
     python_requires='>=2.7, <4',
     project_urls={  # Optional
         'Source': 'https://github.com/agilgur5/django-api-decorators/',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='django-api-decorators',
-    version='0.0.2',
+    version='0.0.3',
     description=('Tiny decorator functions to make it easier to build an ' +
                  'API using Django in ~100 LoC'),
     long_description=long_description,


### PR DESCRIPTION
From the v0.0.3 commit message:
```
- adds django_api_decorators module
  - previously had to import via decorators module, which was
    unintuitive and unintentional
    - can still use decorators module if you were using it before;
      there are no breaking changes made in this patch release, but
      it is deprecated and will be removed when v1.0.0 rolls around
- fixes incorrect module name used in Usage docs

- adds CHANGELOG.md
- adds Django 2.2 classifier
- some other minor docs improvements around badges

- purely internal changes:
  - adds changelog.sh script
```

Basically, all the changes in [django-serializable-model@v0.0.4](https://github.com/agilgur5/django-serializable-model/releases/tag/v0.0.4), which is changes to its `v0.0.3` before and including https://github.com/agilgur5/django-serializable-model/pull/3 . This resolves the same bug that this library has as was found in https://github.com/agilgur5/django-serializable-model/issues/2 .

Changes before that PR fix in `django-serializable-model` were all docs, changelog, and packaging updates.